### PR TITLE
Make flash offset configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ USAGE: espruino ...options... [file_to_upload.js]
   -o out.js               : Write the actual JS code sent to Espruino to a file
   -f firmware.bin         : Update Espruino's firmware to the given file
                               Espruino must be in bootloader mode
+                              Optionally skip N first bytes of the bin file,
   -e command              : Evaluate the given expression on Espruino
                               If no file to upload is specified but you use -e,
                               Espruino will not be reset

--- a/core/env.js
+++ b/core/env.js
@@ -12,7 +12,7 @@
 "use strict";
 (function(){
   
-  var JSON_DIR = "http://www.espruino.com/json/";
+  var DEFAULT_JSON_DIR = "http://www.espruino.com/json/";
   
   var environmentData = {};
   var boardData = {};
@@ -85,14 +85,21 @@
   
   /** Get a list of boards that we know about */
   function getBoardList(callback) {
-    Espruino.Core.Utils.getJSONURL(JSON_DIR + "boards.json", function(boards){
+    var jsonDir = Espruino.Config.BOARD_JSON_URL || DEFAULT_JSON_DIR;
+
+    // ensure jsonDir ends with slash
+    if (jsonDir.indexOf('/', jsonDir.length - 1) === -1) {
+      jsonDir += '/';
+    }
+
+    Espruino.Core.Utils.getJSONURL(jsonDir + "boards.json", function(boards){
      // now load all the individual JSON files 
       var promises = [];      
       for (var boardId in boards) {
         promises.push((function() {
           var id = boardId;
           return new Promise(function(resolve, reject) {
-            Espruino.Core.Utils.getJSONURL(JSON_DIR + boards[boardId].json, function (data) {
+            Espruino.Core.Utils.getJSONURL(jsonDir + boards[boardId].json, function (data) {
               boards[id]["json"] = data;
               resolve();
             });

--- a/core/flasher.js
+++ b/core/flasher.js
@@ -306,10 +306,11 @@
     }
 
     if (typeof binary == "string") {
-      var a = new ArrayBuffer(binary.length);
+      var buf = new ArrayBuffer(binary.length);
+      var a = new Uint8Array(buf);
       for (var i=0;i<binary.length;i++)
         a[i] = binary.charCodeAt(i);
-      binary = a;
+      binary = buf;
     }
     // add serial listener
     dataReceived = undefined;

--- a/core/flasher.js
+++ b/core/flasher.js
@@ -250,7 +250,6 @@
 
   var writeAllData = function(binary, flashOffset, callback) {
     var chunkSize = 256;
-    flashOffset = flashOffset || DEFAULT_FLASH_OFFSET;
     console.log("Writing "+binary.byteLength+" bytes");
     Espruino.Core.Status.setStatus("Writing flash...",  binary.byteLength);
     var writer = function(offset) {
@@ -272,7 +271,6 @@
   };
 
   var readAllData = function(binaryLength, flashOffset, callback) {
-    flashOffset = flashOffset || DEFAULT_FLASH_OFFSET;
     var data = new Uint8Array(flashOffset);
     var chunkSize = 256;
     console.log("Reading "+binaryLength+" bytes");
@@ -303,7 +301,9 @@
       flashOffset = null;
     }
 
-    flashOffset = flashOffset || DEFAULT_FLASH_OFFSET;
+    if (!flashOffset && flashOffset !== 0) {
+      flashOffset = DEFAULT_FLASH_OFFSET;
+    }
 
     if (typeof binary == "string") {
       var a = new ArrayBuffer(binary.length);

--- a/index.js
+++ b/index.js
@@ -159,7 +159,13 @@ exports.expr = function(port, expr, callback) {
 
 
 /** Flash the given firmware file to an Espruino board. */
-exports.flash = function(port, filename, callback) {
+exports.flash = function(port, filename, flashOffset, callback) {
+  if (typeof flashOffset === 'function') {
+    // backward compatibility if flashOffset is missed
+    callback = flashOffset;
+    flashOffset = null;
+  }
+
   var code = fs.readFileSync(filename, {encoding:"utf8"});
   init(function() {
     Espruino.Core.Serial.startListening(function(data) { });
@@ -168,7 +174,8 @@ exports.flash = function(port, filename, callback) {
         console.error("Unable to connect!");
         return callback();
       }
-      Espruino.Core.Flasher.flashBinaryToDevice(fs.readFileSync(filename, {encoding:"binary"}), function(err) {
+      var bin = fs.readFileSync(filename, {encoding:"binary"});
+      Espruino.Core.Flasher.flashBinaryToDevice(bin, flashOffset, function(err) {
         console.log(err ? "Error!" : "Success!");
         setTimeout(function() {
           Espruino.Core.Serial.close();

--- a/plugins/boardJSON.js
+++ b/plugins/boardJSON.js
@@ -24,7 +24,7 @@
     
     Espruino.addProcessor("environmentVar", function(env, callback) {
       if (env!==undefined && env.BOARD!==undefined) {
-        var jsonPath = Espruino.Config.BOARD_JSON_URL+"/"+env.BOARD+".json";
+        var jsonPath = env.JSON_URL || Espruino.Config.BOARD_JSON_URL+"/"+env.BOARD+".json";
         console.log("Loading "+jsonPath);
         Espruino.Core.Utils.getJSONURL(jsonPath, function(data){
           console.log("Board JSON loaded");


### PR DESCRIPTION
Now offset for flashing via serial is configurable.

Changes are backward compatible. Required flash offset is got from `chip.place_text_section`. If it is missing 1024×10 is used.

Also flashing from espruino-cli has been repaired. Previously due to the bug of flasher.js the board was flashed with nulls.
