### PR TITLE
Bleat required regardless of BLE flag in CLI

### DIFF
--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -34,7 +34,7 @@ for (var i=2;i<process.argv.length;i++) {
    else if (arg=="-m" || arg=="--minify") args.minify = true;
    else if (arg=="-t" || arg=="--time") args.setTime = true;
    else if (arg=="-w" || arg=="--watch") args.watchFile = true;
-   else if (arg=="--ble") args.ble = true;
+   else if (arg=="--no-ble") args.noBle = true;
    else if (arg=="--list") args.showDevices = true;
    else if (arg=="-p" || arg=="--port") {
      args.ports.push(next);
@@ -81,8 +81,8 @@ function setupConfig(Espruino) {
    Espruino.Config.MINIFICATION_LEVEL = "ESPRIMA";
  if (args.baudRate && !isNaN(args.baudRate))
    Espruino.Config.BAUD_RATE = args.baudRate;
- if (args.ble)
-   Espruino.Config.BLUETOOTH_LOW_ENERGY = true;
+ if (args.noBle)
+   Espruino.Config.BLUETOOTH_LOW_ENERGY = false;
  if (args.setTime)
    Espruino.Config.SET_TIME_ON_WRITE = true;
  if (args.watchFile && !args.file)
@@ -114,7 +114,7 @@ if (args.help) {
   "  -p,--port /dev/ttyX     : Specify port(s) to connect to",
   "  -b baudRate             : Set the baud rate of the serial connection",
   "                              No effect when using USB, default: 9600",
-  "  --ble                   : Try and connect with Bluetooth Low Energy (using the 'bleat' module)",
+  "  --no-ble                : Disables Bluetooth Low Energy (using the 'bleat' module)",
   "  --list                  : List all available devices and exit",
   "  -t,--time               : Set Espruino's time when uploading code",
   "  -o out.js               : Write the actual JS code sent to Espruino to a file",

--- a/core/serial_bleat.js
+++ b/core/serial_bleat.js
@@ -8,7 +8,15 @@
 
   if (typeof require === 'undefined') return;
   var bleat = undefined;
-  try {
+ 
+var NORDIC_SERVICE = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
+var NORDIC_TX = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";
+var NORDIC_RX = "6e400003-b5a3-f393-e0a9-e50e24dcca9e";
+
+var initialised = false;
+function checkInit(callback) {
+  
+   try {
     bleat = require('bleat');
     if (bleat.classic) bleat = bleat.classic;
   } catch (e) {
@@ -17,12 +25,6 @@
     return;
   }
 
-var NORDIC_SERVICE = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
-var NORDIC_TX = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";
-var NORDIC_RX = "6e400003-b5a3-f393-e0a9-e50e24dcca9e";
-
-var initialised = false;
-function checkInit(callback) {
   if (initialised || !bleat.init) callback(null);
   else {
     bleat.init(function() {
@@ -74,7 +76,7 @@ var scanStopTimeout = undefined;
       name : "Connect over Bluetooth Smart (BTLE) via 'bleat'",
       descriptionHTML : 'Allow connection to Espruino via BLE with the Nordic UART implementation',
       type : "boolean",
-      defaultValue : true,
+      defaultValue : false,
     });
   }
 

--- a/core/serial_bleat.js
+++ b/core/serial_bleat.js
@@ -75,7 +75,7 @@
       name: "Connect over Bluetooth Smart (BTLE) via 'bleat'",
       descriptionHTML: 'Allow connection to Espruino via BLE with the Nordic UART implementation',
       type: "boolean",
-      defaultValue: false,
+      defaultValue: true
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "espruino",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Command Line Interface and library for Communications with Espruino JavaScript Microcontrollers",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
**Problem:**

On Windows, when a non-compatible USB Bluetooth 4.0 wasn't found, it caused a massive stage trace to appear regardless if you wanted to use `ble` flag.

```
Error: No compatible USB Bluetooth 4.0 device found!
    at BluetoothHciSocket.bindUser (C:\Users\andre\Projects\test_craig\node_modules\noble\node_modules\bluetooth-hci-socket\lib\usb.js:70:11)
    at BluetoothHciSocket.bindRaw (C:\Users\andre\Projects\test_craig\node_modules\noble\node_modules\bluetooth-hci-socket\lib\usb.js:28:8)
    at Hci.init (C:\Users\andre\Projects\test_craig\node_modules\noble\lib\hci-socket\hci.js:99:35)
    at NobleBindings.init (C:\Users\andre\Projects\test_craig\node_modules\noble\lib\hci-socket\bindings.js:83:13)
    at new Noble (C:\Users\andre\Projects\test_craig\node_modules\noble\lib\noble.js:50:18)
    at Object.<anonymous> (C:\Users\andre\Projects\test_craig\node_modules\noble\index.js:4:18)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
```
The problem was that bleat was always being "tried" to be included outside of the `checkInit()` thus always being required and that the `defaultValue` was always `true`.

**Solution:**
Set `defaultValue` to be `false` and include `bleat` only when necessary.

I also did a version bump to 0.0.21.

 