### PR TITLE
Commandline Interface Job File

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ When installed as a Node module with `npm install -g espruino` you get a command
 USAGE: espruino ...options... [file_to_upload.js]
 
   -h,--help               : Show this message
+  -j job.json             : Load options from JSON job file - see configDefaults.json for example,
+  -c,--color              : Color mode,
   -v,--verbose            : Verbose
   -q,--quiet              : Quiet - apart from Espruino output
   -m,--minify             : Minify the code before sending it

--- a/configDefaults.json
+++ b/configDefaults.json
@@ -1,0 +1,31 @@
+{
+  "verbose": false,
+  "quiet": false,
+  "color": false,
+  "minify": false,
+  "setTime": false,
+  "watchFile": false,
+  "no-ble": false,
+  "showDevices": false,
+  "ports": [""],
+  "expr": "",
+  "baudRate": 0,
+  "outputJS": "",
+  "updateFirmware": "",
+  "firmwareFlashOffset": 0,
+  "file": "",
+  "espruino": {
+    "MODULE_URL": "http://www.espruino.com/modules",
+    "MODULE_EXTENSIONS": ".min.js|.js",
+    "MODULE_AS_FUNCTION": false,
+    "RESET_BEFORE_SEND": true,
+    "STORE_LINE_NUMBERS": true,
+    "ENV_ON_CONNECT": true,
+    "BAUD_RATE": 9600,
+    "SERIAL_AUDIO": 0,
+    "BLUETOOTH_LOW_ENERGY": true,
+    "SERIAL_TCPIP": "",
+    "WEB_BLUETOOTH": true
+  }
+}
+

--- a/core/modules.js
+++ b/core/modules.js
@@ -118,15 +118,17 @@
             // otherwise try and load the module the old way...
             console.log("loadModule("+fullModuleName+")");
             
-            var urls; // Array of where to look for this module
+            var urls = []; // Array of where to look for this module
             var modName; // Simple name of the module
             if(Espruino.Core.Utils.isURL(fullModuleName)) {
               modName = fullModuleName.substr(fullModuleName.lastIndexOf("/") + 1).split(".")[0];
               urls = [ fullModuleName ];
             } else {
               modName = fullModuleName;
-              urls = Espruino.Config.MODULE_EXTENSIONS.split("|").map(function (extension) {
-                return Espruino.Config.MODULE_URL + "/" + fullModuleName + extension;
+              Espruino.Config.MODULE_URL.split("|").forEach(function (url) {
+                Espruino.Config.MODULE_EXTENSIONS.split("|").forEach(function (extension) {
+                  urls.push(url + "/" + fullModuleName + extension);
+                })
               });
             };
             


### PR DESCRIPTION
Added a commandline tool option "-j job.json" to load a job file with all of the commandline options as a JSON configuration alternative and in support of other options not covered by the commandline arguments. Included a configDefaults.json file as an example. Modified modules.js to accept multiple URL specs same as WebIDE. Updated README.md, respectively.