### PR TITLE
Fix Github module loading in CLI

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -302,9 +302,10 @@
       if (result.data!==undefined) {
         callback(result.data);
       } else {
+        var resultUrl = result.url ? result.url : url;
         if (typeof process === 'undefined') {
           // Web browser
-          $.get( url, function(d) {
+          $.get( resultUrl, function(d) {
             callback(d);
           }, "text").error(function(xhr,status,err) {
             console.error(err);
@@ -312,8 +313,9 @@
           });
         } else {
           // Node.js
-          if (url.substr(0,4)=="http") {
-            require("http").get(url, function(res) {
+          if (resultUrl.substr(0,4)=="http") {
+            var m = resultUrl[4]=="s"?"https":"http";
+            require(m).get(resultUrl, function(res) {
               if (res.statusCode != 200) {
                 console.error("Espruino.Core.Utils.getURL: got HTTP status code "+res.statusCode+" for "+url);
                 return callback(undefined);
@@ -328,7 +330,7 @@
               callback(undefined);
             });
           } else {
-            require("fs").readFile(url, function(err, d) {
+            require("fs").readFile(resultUrl, function(err, d) {
               if (err) {
                 console.error(err);
                 callback(undefined);

--- a/plugins/getGitHub.js
+++ b/plugins/getGitHub.js
@@ -17,9 +17,7 @@
   }
   
   function getGitHub(data, callback) {
-    var match = undefined;
-    if (!match) match = data.url.match(/^https?:\/\/github.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.*)$/);
-    if (!match) match = data.url.match(/^https?:\/\/raw.githubusercontent.com\/([^\/]+)\/([^\/]+)\/([^\/]+)\/(.*)$/);
+    var match = data.url.match(/^https?:\/\/github.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.*)$/);
     if (match) {
       var git = {
           owner : match[1],
@@ -28,19 +26,9 @@
           path : match[4]
           };
       
+      var url = "https://raw.githubusercontent.com/"+git.owner+"/"+git.repo+"/"+git.branch+"/"+git.path;
       console.log("Found GitHub", JSON.stringify(git));
-      var apiURL = "https://api.github.com/repos/"+git.owner+"/"+git.repo+"/contents/"+git.path+"?ref="+git.branch;
-      Espruino.Core.Utils.getJSONURL(apiURL, function(json) {
-        if (json &&
-            json.type=="file" &&
-            json.encoding=="base64") {
-          // just load it...
-          data.data = window.atob(json.content);
-        } else {
-          console.log("GET of "+apiURL+" returned JSON that wasn't a base64 encoded file");          
-        }
-        callback(data);
-      });
+      callback({url: url});
     } else
       callback(data); // no match - continue as normal
   }


### PR DESCRIPTION
**Problem:**
For any required Github module, the CLI would return the following and
ignore the module:
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3):
Error: Protocol "https:" not supported. Expected "http:"

**Reason:**
The getGitHub plugin queried the Github Contents API, but didn't set the
User-Agent as mandated by the API rules, so the API always returned 403,
the plugin thus failed, and the original URL got resolved by
Core.Utils.getURL.

In the CLI, Core.Utils.getURL uses the "http" node module, which only
resolves HTTP, not HTTPS. However, Github uses HSTS (automatically
redirects all HTTP requests to HTTPS requests). Therefore Github modules
couldn't be downloaded from the CLI.

**Fix:**
* FIX Core.Utils.getURL to require either the "http" or "https" module,
  depending on the protocol
* CHANGE getGitHub to no longer use the Github Contents API, but instead
  * no longer match "githubusercontent" URLs and let them be handled by
    getURL
  * for backwards compatibility, still match the "blob" URLs, but
    rewrite them to "githubusercontent" format
* CHANGE Core.Utils.getURL to allow "getURL" processors to also return
  changed URL, not just resolved data

**Notes:**
A possible solution was to just set the "User-Agent" on the HTTP request, but that:
* required parsing the URL and passing its parts as options to http module
* uncovered a problem, that the current solution for base64-decoding the API response (`window.atob`) doesn't work in Node and would need a different implementation

I **didn't** verify that this works for the Web IDE (but believe it should). It does fix the CLI though.