### PR TITLE
Fix 'sendCode is not defined' error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,9 @@ exports.sendFile = function(port, filename, callback) {
   sendCode(port, code, callback);
 };
 
-exports.sendCode = function sendCode(port, code, callback) {
+exports.sendCode = sendCode;
+
+function sendCode(port, code, callback) {
   init(function() {
     Espruino.Core.Serial.startListening(function(data) { });
     Espruino.Core.Serial.open(port, function(status) {


### PR DESCRIPTION
My code which prompted the error, basically copied from https://www.npmjs.com/package/espruino.
```javascript
var Espruino = require("espruino")

Espruino.init(function(){

	Espruino.sendFile(com, './build/morra.min.js', function(){

		console.log('Done!')
	})
})
```

```/Users/rob/projects/espruino2/node_modules/espruino/index.js:118
  sendCode(port, code, callback);
  ^

ReferenceError: sendCode is not defined
    at Object.exports.sendFile (/Users/rob/projects/espruino2/node_modules/espruino/index.js:118:3)
    at /Users/rob/projects/espruino2/build.js:60:14
    at Object.init (/Users/rob/projects/espruino2/node_modules/espruino/index.js:107:3)
    at /Users/rob/projects/espruino2/build.js:58:13
    at Compiler.<anonymous> (/Users/rob/projects/espruino2/node_modules/webpack/lib/Compiler.js:194:14)
    at Compiler.emitRecords (/Users/rob/projects/espruino2/node_modules/webpack/lib/Compiler.js:282:37)
    at Compiler.<anonymous> (/Users/rob/projects/espruino2/node_modules/webpack/lib/Compiler.js:187:11)
    at /Users/rob/projects/espruino2/node_modules/webpack/lib/Compiler.js:275:11
    at Compiler.applyPluginsAsync (/Users/rob/projects/espruino2/node_modules/tapable/lib/Tapable.js:60:69)
    at Compiler.afterEmit (/Users/rob/projects/espruino2/node_modules/webpack/lib/Compiler.js:272:8)
```

Seems that hoisting doesn't work when named functions are to the right of an assignment operation.