### PR TITLE
Proxy support for fetching required modules

### DIFF
--- a/core/modules.js
+++ b/core/modules.js
@@ -32,8 +32,32 @@
       name : "Modules uploaded as functions (BETA)",
       description : "Espruino 1v90 and later ONLY. Upload modules as Functions, allowing any functions inside them to be loaded directly from flash when 'Save on Send' is enabled.",
       type : "boolean",
-      defaultValue : false, 
-    });    
+      defaultValue : false
+    });
+    
+    Espruino.Core.Config.add("MODULE_PROXY_ENABLED", {
+      section : "Communications",
+      name : "Enable Proxy",
+      description : "Enable Proxy for loading the modules when `require()` is used (only in native IDE)",
+      type : "boolean",
+      defaultValue : false
+    });
+
+    Espruino.Core.Config.add("MODULE_PROXY_URL", {
+      section : "Communications",
+      name : "Proxy URL",
+      description : "Proxy URL for loading the modules when `require()` is used (only in native IDE)",
+      type : "string",
+      defaultValue : ""
+    });
+
+    Espruino.Core.Config.add("MODULE_PROXY_PORT", {
+      section : "Communications",
+      name : "Proxy Port",
+      description : "Proxy Port for loading the modules when `require()` is used (only in native IDE)",
+      type : "string",
+      defaultValue : ""
+    });
     
     // When code is sent to Espruino, search it for modules and add extra code required to load them 
     Espruino.addProcessor("transformForEspruino", function(code, callback) {

--- a/core/utils.js
+++ b/core/utils.js
@@ -319,6 +319,15 @@
           // Node.js
           if (resultUrl.substr(0,4)=="http") {
             var m = resultUrl[4]=="s"?"https":"http";
+
+            var http_options = Espruino.Config.MODULE_PROXY_ENABLED ? {
+              host: Espruino.Config.MODULE_PROXY_URL,
+              port: Espruino.Config.MODULE_PROXY_PORT,
+              path: resultUrl,
+            } : {
+              host: resultUrl
+            };
+            
             require(m).get(resultUrl, function(res) {
               if (res.statusCode != 200) {
                 console.error("Espruino.Core.Utils.getURL: got HTTP status code "+res.statusCode+" for "+url);

--- a/core/utils.js
+++ b/core/utils.js
@@ -324,11 +324,9 @@
               host: Espruino.Config.MODULE_PROXY_URL,
               port: Espruino.Config.MODULE_PROXY_PORT,
               path: resultUrl,
-            } : {
-              host: resultUrl
-            };
+            } : resultUrl;
             
-            require(m).get(resultUrl, function(res) {
+            require(m).get(http_options, function(res) {
               if (res.statusCode != 200) {
                 console.error("Espruino.Core.Utils.getURL: got HTTP status code "+res.statusCode+" for "+url);
                 return callback(undefined);


### PR DESCRIPTION
I discovered that the IDE in its native version can't fetch modules which are loaded using the 'required' statement when there is a proxy server restricting access to the internet (e.g. in a company network).

So I've added configuration options to configure a proxy server and the respective code to fetch the modules via the configured proxy server when the IDE is running in native mode.
