### PR TITLE
Update espruino-cli.js

### DIFF
--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -39,7 +39,7 @@ function getHelp() {
    "as a terminal for communicating directly with Espruino. Press Ctrl-C",
    "twice to exit.",
    "",
-   "Please report bugs via https://github.com/espruino/EspruinoTool/issues",
+   "Please report bugs via https://github.com/espruino/EspruinoTools/issues",
    ""]
 }
 


### PR DESCRIPTION
error in URL for bug reports from --help output 
- missing 's' in project name
