### PR TITLE
Fix Typo in serial port connection initialisation

### DIFF
--- a/core/serial_nodeserial.js
+++ b/core/serial_nodeserial.js
@@ -59,7 +59,7 @@ Gordon Williams (gw@pur3.co.uk)
   var openSerial=function(serialPort, openCallback, receiveCallback, disconnectCallback) {
     // https://github.com/voodootikigod/node-serialport#reference-guide
     connection = new serialport(serialPort, {
-        baudrate: parseInt(Espruino.Config.BAUD_RATE)
+        baudRate: parseInt(Espruino.Config.BAUD_RATE)
     });
     connection.on('open', function() {
       openCallback("Ok");


### PR DESCRIPTION
baudrate -> baudRate
as described in https://github.com/node-serialport/node-serialport#usage

Call: 
node espruino-cli.js -b 115200 -p COM5 -v
Result:
(node:216) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: "baudrate" is an unknown option, did you mean "baudRate"?