### PR TITLE
Fix for #32 connect over TCP/IP using CLI

### DIFF
--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -554,6 +554,11 @@ function startConnect() {
   if ((!args.file && !args.updateFirmware && !args.expr) || (args.file && args.watchFile)) {
     if (args.ports.length != 1)
       throw new Error("Can only have one port when using terminal mode");
+
+    if ( args.ports[0].name.substr(0, 6)==="tcp://" ) {
+      Espruino.Config.SERIAL_TCPIP=args.ports[0].name; // ensure node serial will return this uri
+    }  
+
     getPortPath(args.ports[0], function(path) {
       terminal(path, function() { process.exit(0); });
     });

--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -186,6 +186,16 @@ function setupConfig(Espruino, callback) {
      Espruino.Config[key] = args.config[key];
    }
  }
+ if ( args.ports && args.ports.length ) {
+   Espruino.Config.SERIAL_TCPIP=args.ports
+    .filter(function(p) {
+      return p.name.substr(0,6) === "tcp://";
+    })
+    .map(function(p) {
+      return p.name.trim();
+    }
+   )
+ }
  if (args.showConfigs) {
    Espruino.Core.Config.getSections().forEach(function(section) {
      log(" "+section.name);
@@ -554,10 +564,6 @@ function startConnect() {
   if ((!args.file && !args.updateFirmware && !args.expr) || (args.file && args.watchFile)) {
     if (args.ports.length != 1)
       throw new Error("Can only have one port when using terminal mode");
-
-    if ( args.ports[0].name.substr(0, 6)==="tcp://" ) {
-      Espruino.Config.SERIAL_TCPIP=args.ports[0].name; // ensure node serial will return this uri
-    }  
 
     getPortPath(args.ports[0], function(path) {
       terminal(path, function() { process.exit(0); });

--- a/core/serial_node_socket.js
+++ b/core/serial_node_socket.js
@@ -32,15 +32,11 @@ Author: Alfie Kirkpatrick (jugglingcats@akirkpatrick.com)
   var socket;
 
   var getPorts = function (callback) {
-    var uri = Espruino.Config.SERIAL_TCPIP || "";
-    if (uri.trim() != "") {
-      var ips = uri.trim().split(";");
-      var portList = [];
-      ips.forEach(function (s) {
-        s = s.trim();
-        if (s.length) portList.push({ path: s, description: "Network connection", type: "socket" });
-      })
-      callback(portList);
+    var config=Espruino.Config.SERIAL_TCPIP;
+    if ( config && config.length ) {
+      callback(config.map(function(p) {
+        return { path: p, description: "Network connection", type: "socket" };
+      }));
     } else
       callback();
   };

--- a/core/serial_node_socket.js
+++ b/core/serial_node_socket.js
@@ -32,7 +32,7 @@ Author: Alfie Kirkpatrick (jugglingcats@akirkpatrick.com)
   var socket;
 
   var getPorts = function (callback) {
-    var uri = Espruino.Config.SERIAL_TCPIP;
+    var uri = Espruino.Config.SERIAL_TCPIP || "";
     if (uri.trim() != "") {
       var ips = uri.trim().split(";");
       var portList = [];

--- a/core/serial_node_socket.js
+++ b/core/serial_node_socket.js
@@ -1,0 +1,102 @@
+/**
+Copyright (c) 2018 Espruino Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Alfie Kirkpatrick (jugglingcats@akirkpatrick.com)
+**/
+
+(function () {
+  var PREFIX = "tcp://"; // prefix to use with -p option for hostname/ip address
+
+  if (typeof require === 'undefined') return; // definitely not node!
+
+  var net;
+  try {
+    net = require("net");
+  } catch (e) {
+    console.log("Require net failed - Node Socket disabled");
+    return;
+  }
+
+  var socket;
+
+  var getPorts = function (callback) {
+    var uri = Espruino.Config.SERIAL_TCPIP;
+    if (uri.trim() != "") {
+      var ips = uri.trim().split(";");
+      var portList = [];
+      ips.forEach(function (s) {
+        s = s.trim();
+        console.log("ADDING", s);
+        if (s.length) portList.push({ path: s, description: "Network connection", type: "socket" });
+      })
+      callback(portList);
+    } else
+      callback();
+  };
+
+  var openSerial = function (serialPort, openCallback, receiveCallback, disconnectCallback) {
+    if (serialPort.substr(0, 6) != 'tcp://') {
+      console.error("Invalid connection " + JSON.stringify(serialPort));
+      return;
+    }
+    var host = serialPort.substr(6);
+    var port = 23;
+    if (host.indexOf(":") >= 0) {
+      var i = host.indexOf(":");
+      port = parseInt(host.substr(i + 1).trim());
+      host = host.substr(0, i).trim();
+      if (host == "") host = "localhost";
+    }
+
+    socket = net.createConnection(port, host, function (createInfo) {
+      openCallback("Ok");
+    });
+    socket.on("data", function (data) {
+      if (receiveCallback !== undefined) {
+        var a = new Uint8Array(data.length);
+        for (var i = 0; i < data.length; i++)
+          a[i] = data[i];
+        receiveCallback(a.buffer);
+      }
+    });
+    socket.on("error", function (info) {
+      console.error("RECEIVE ERROR:", JSON.stringify(info));
+      // node will close the connection
+    });
+    socket.on("end", function () {
+      if (disconnectCallback !== undefined) {
+        disconnectCallback();
+      }
+    });
+  };
+
+  var closeSerial = function () {
+    if (socket) {
+      socket.end();
+    }
+  };
+
+  var writeSerial = function (data, callback) {
+    socket.write(data, undefined, callback);
+  };
+
+  Espruino.Core.Serial.devices.push({
+    "name": "Node Socket",
+    "getPorts": getPorts,
+    "open": openSerial,
+    "write": writeSerial,
+    "close": closeSerial,
+  });
+})();

--- a/core/serial_node_socket.js
+++ b/core/serial_node_socket.js
@@ -38,7 +38,6 @@ Author: Alfie Kirkpatrick (jugglingcats@akirkpatrick.com)
       var portList = [];
       ips.forEach(function (s) {
         s = s.trim();
-        console.log("ADDING", s);
         if (s.length) portList.push({ path: s, description: "Network connection", type: "socket" });
       })
       callback(portList);


### PR DESCRIPTION
Hi @gfwilliams the node socket part was fairly trivial using a combination of the chrome socket and existing node serial files.

I wasn't sure the best way for this driver to respond to `getPorts`, because all the others are able to iterate available ports/connections, whereas this just wants to use what is given in the `-p` parameter on the CLI.

I've added a small hack to `espruino-cli.js` to look for a uri of the form `tcp://xxxxxx` and shove this in `Espruino.Config.SERIAL_TCPIP` (key used by chrome sockets).

So the user just has to use `espruino -p tcp://a.b.c.d[:port]` and it should work.

Feel free to suggest better approach but otherwise if you're happy I'll make a pull request for the docs to explain the `tcp://` syntax.