### PR TITLE
fix(cli): gracefully fail on ports without a description

### DIFF
--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -548,7 +548,7 @@ function getPortPath(port, callback) {
     var timeout = 2;
     Espruino.Core.Serial.getPorts(function cb(ports, shouldCallAgain) {
       //log(JSON.stringify(ports,null,2));
-      var found = ports.find(function(p) { return p.description.toLowerCase().indexOf(searchString)>=0; });
+      var found = ports.find(function(p) { return p.description && p.description.toLowerCase().indexOf(searchString)>=0; });
       if (found) {
         log("Found "+JSON.stringify(found.description)+" ("+JSON.stringify(found.path)+")");
         callback(found.path);


### PR DESCRIPTION
When running the CLI with the `-d deviceName` flag, I am getting a fatal error during scan because one of the ports doesn't have a `description` field:

```
espruino -d Puck
Espruino Command-line Tool 0.1.11
-----------------------------------

Searching for device named "Puck"
/usr/local/lib/node_modules/espruino/bin/espruino-cli.js:552
        return p.description.toLowerCase().indexOf(searchString)>=0;
                             ^

TypeError: Cannot read property 'toLowerCase' of undefined
    at /usr/local/lib/node_modules/espruino/bin/espruino-cli.js:552:30
    at Array.find (native)
    at cb (/usr/local/lib/node_modules/espruino/bin/espruino-cli.js:550:25)
    at eval (eval at loadJS (/usr/local/lib/node_modules/espruino/index.js:10:10), <anonymous>:95:11)
    at getPorts (eval at loadJS (/usr/local/lib/node_modules/espruino/index.js:10:10), <anonymous>:150:7)
    at Timeout.eval [as _onTimeout] (eval at loadJS (/usr/local/lib/node_modules/espruino/index.js:10:10), <anonymous>:76:13)
    at ontimeout (timers.js:482:11)
    at tryOnTimeout (timers.js:317:5)
    at Timer.listOnTimeout (timers.js:277:5)
```

This change simply ignores any port without a description.