### PR TITLE
fix: report devices after scanning has finished

### DIFF
--- a/core/serial_noble.js
+++ b/core/serial_noble.js
@@ -71,11 +71,7 @@
       if (scanWhenInitialised) {
         var scb = scanWhenInitialised;
         scanWhenInitialised = undefined;
-        getPorts(function() {
-          setTimeout(function() {
-            getPorts(scb);
-          }, 1500);
-        });
+        getPorts(scb);
       }
     }
     if (state=="poweredOff") {
@@ -137,24 +133,25 @@
         scanStopTimeout = undefined;
         console.log("Noble: Stopping scan");
         noble.stopScanning();
-      }, 3000);
-      // report back device list from both the last scan and this one...
-      var reportedDevices = [];
-      newDevices.forEach(function (d) {
-        reportedDevices.push(d);
-      });
-      lastDevices.forEach(function (d) {
-        var found = false;
-        reportedDevices.forEach(function (dv) {
-          if (dv.path == d.path) found = true;
+
+        // report back device list from both the last scan and this one...
+        var reportedDevices = [];
+        newDevices.forEach(function (d) {
+          reportedDevices.push(d);
         });
-        if (!found) reportedDevices.push(d);
-      });
-      reportedDevices.sort(function (a, b) { return a.path.localeCompare(b.path); });
-      lastDevices = newDevices;
-      newDevices = [];
-      //console.log("Noble: reportedDevices",reportedDevices);
-      callback(reportedDevices, false/*instantPorts*/);
+        lastDevices.forEach(function (d) {
+          var found = false;
+          reportedDevices.forEach(function (dv) {
+            if (dv.path == d.path) found = true;
+          });
+          if (!found) reportedDevices.push(d);
+        });
+        reportedDevices.sort(function (a, b) { return a.path.localeCompare(b.path); });
+        lastDevices = newDevices;
+        newDevices = [];
+        //console.log("Noble: reportedDevices",reportedDevices);
+        callback(reportedDevices, false/*instantPorts*/);
+      }, 3000);
     }
   };
 
@@ -233,7 +230,7 @@
       return callback();
     }
 
-    console.error("BT> send "+JSON.stringify(data));
+    console.log("BT> send "+JSON.stringify(data));
     txInProgress = true;
     try {
       txCharacteristic.write(Espruino.Core.Utils.stringToBuffer(data), false, function() {


### PR DESCRIPTION
In trying to use the CLI module to upload code and debug using the REPL, I was noticing some strange behavior when scanning. Both scanning with and without the `d` flag was consistently not returning my Espruino device even though it was powered on with no active connection.

It seems the callback with results was being fired while Noble was still scanning. This was somewhat mitigated because the CLI calls the scanning function before Noble has powered on, in which case `getPorts` was being called twice in the span of 1.5 seconds. Sometimes the Espruino would show up in this 1.5 seconds on one scan but then when my script attempted to run the CLI with the appropriate port command, the next scan wouldn't find the device in time and would fail out.

This may be slightly unique to my environment since I have a few Bluetooth devices around when I start the scan. In any case I've moved the callback inside of the `scanStopTimeout` block to ensure that a complete scan is run before results are returned.

It appears to mitigate the issue for me on the CLI, and my Espruino devices are returned consistently. However, I'm aware this may have been a deliberate decision since I am relatively new to the framework. If there's anything else I need to factor in here let me know!

Also, the REPL is difficult to use with the 0.1.11 update because all BLE communication is logged out to the console as you type. I just swapped for a `console.log` which keeps the communication hidden unless using the `verbose` flag.