### PR TITLE
Upgrade of serialport (7.1.3) fixing crash at open port on macos/unix

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "optionalDependencies": {
     "noble": "^1.9.1",
-    "serialport": "^7.0.2",
+    "serialport": "^7.1.3",
     "winnus": "",
     "websocket": "^1.0.28"
   },


### PR DESCRIPTION
Upgrade `serialport` package to version 7.1.3 to fix https://github.com/node-serialport/node-serialport/issues/1772 