### PR TITLE
Update package.json with newer version of 'noble'

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "utf8": "^2.1.2"
   },
   "optionalDependencies": {
-    "noble": "^1.9.1",
+    "@abandonware/noble": "^1.9.2-2",
     "serialport": "^7.1.4",
     "winnus": "",
     "websocket": "^1.0.28"


### PR DESCRIPTION
The npm package `noble` is old and relies on `bluetooth-hci-socket` which is outdated and does not build in node 10 or 11.  @abandonware's fork is much more up to date and builds in node up to version 11.15 (though not 12).  