### PR TITLE
fix stdin for terminal

### DIFF
--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -629,8 +629,7 @@ function terminal(devicePath, exitCallback) {
       return exitCallback();
     }
     if (!args.quiet) log("Connected");
-    process.stdin.on('readable', function() {
-      var chunk = process.stdin.read();
+    process.stdin.on('data', function(chunk) {      
       if (chunk !== null) {
         chunk = chunk.toString();
         Espruino.Core.Serial.write(chunk);


### PR DESCRIPTION
#101

`stdin.on("readable")` was outdated, changed to `on("data")`