### PR TITLE
Use configured baud rate for Web Serial

### DIFF
--- a/core/serial_web_serial.js
+++ b/core/serial_web_serial.js
@@ -52,7 +52,7 @@
     navigator.serial.requestPort({}).then(function(port) {
       Espruino.Core.Status.setStatus("Connecting to serial port");
       serialPort = port;
-      return port.open({ baudrate: 115200 });
+      return port.open({ baudrate: parseInt(Espruino.Config.BAUD_RATE) });
     }).then(function () {
       function readLoop() {
         var reader = serialPort.readable.getReader();


### PR DESCRIPTION
This was originally hard-coded to 115200 which doesn't work for all boards. The configured value (defaults to 9600) should be used instead.