### PR TITLE
uploading in a single block to preserve setTimeout order

### DIFF
--- a/espruino.js
+++ b/espruino.js
@@ -90,6 +90,9 @@ var Espruino;
       cbCalled = true;
       if (n < p.length) {
         cbCalled = false;
+        if ( inData !== undefined && typeof inData === "string" ) {
+          inData = "(function() {\n" + inData + "\n})();";
+        }
         p[n++](inData, cb);
       } else {
         if (callback!==undefined) callback(inData);


### PR DESCRIPTION
[forumpost <-](http://forum.espruino.com/conversations/349577/#comment15359086)

```
setTimeout(function() {console.log("after"),0};
console.log("before");
```

will not honour actual behavior if sequential execution of code, because its uploaded line by line, with idle time inbetween.  If you wrap it in a function block then the output behavior is expected.  This is very useful eg on a bangle watch emulation where the position of string on screen eg will be different :

```
var ypos = 5;
setTimeout( function(){
  ypos = ypos + 20;
  g.drawString("timeout", 5, ypos, 0);
},0);
var x =0;
while ( x < 100000 ) {
  x++;
}
ypos = ypos + 20;
g.drawString("final", 5, ypos, 0);
```