### PR TITLE
Rename the baudRate option

### DIFF
--- a/core/serial_web_serial.js
+++ b/core/serial_web_serial.js
@@ -93,7 +93,7 @@
     promise.then(function(port) {
       Espruino.Core.Status.setStatus("Connecting to serial port");
       serialPort = port;
-      return port.open({ baudrate: parseInt(Espruino.Config.BAUD_RATE) });
+      return port.open({ baudRate: parseInt(Espruino.Config.BAUD_RATE) });
     }).then(function () {
       function readLoop() {
         serialPortReader = serialPort.readable.getReader();


### PR DESCRIPTION
Connecting via Web Serial results in TypeError: `Failed to execute 'open' on 'SerialPort': required member baudRate is undefined`;

Using 'baudrate' as an option seems to have worked previously, but the new Chrome version now seems to follow the official specification (https://wicg.github.io/serial/#dom-serialoptions) and baudRate should be written in camelCase;

Tested in Chrome 87.0.4259.3 Canary