### PR TITLE
Make fileSaveDialog work in non-Chrome browsers

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -535,7 +535,7 @@
       Espruino.Core.Notifications.error("Error Saving", true);
     }
 
-    if (chrome.fileSystem) {
+    if (typeof chrome !== 'undefined' && chrome.fileSystem) {
       // Chrome Web App / NW.js
       chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName:filename}, function(writableFileEntry) {
         if (!writableFileEntry) return; // cancelled


### PR DESCRIPTION
Clicking the "Save File" button of the EspruinoWebIDE in non-Chome browsers (i.e. Firefox) fails with the following error printed on console:
```
Uncaught ReferenceError: chrome is not defined
    fileSaveDialog debugger eval code:5
    click https://www.espruino.com/ide/js/core/file.js:57
```

Browsers like Firefox do not have the 'chrome' symbol defined, so check it in fileSaveDialog() function before accessing 'chrome.filesystem'.