### PR TITLE
Support sole '--storage x:x.js'

### DIFF
--- a/bin/espruino-cli.js
+++ b/bin/espruino-cli.js
@@ -417,6 +417,9 @@ function sendCode(callback) {
       Espruino.Config.RESET_BEFORE_SEND = false;
     code += args.expr+"\n";
   }
+  if (Object.keys(args.storageContents).length && !code) {
+    code += "\n";
+  }
   if (code) {
     var env = Espruino.Core.Env.getData();
     if (!env.info || !env.info.builtin_modules) {


### PR DESCRIPTION
Currently in order to upload a file one has to provide code file or expression on the command line like:
```
espruino -e " " --storage rf:rf.js
```

This makes it so that the code/expression is not needed to upload storage file as:
```
espruino --storage rf:rf.js
```
