### PR TITLE
Remove '-' in service uuids to properly match NORDIC_SERVICE

### DIFF
--- a/core/serial_noble.js
+++ b/core/serial_noble.js
@@ -105,7 +105,7 @@
         if (newDevices[i].path == dev.address) return; // already seen it
       var name = dev.advertisement.localName || dev.address;
       var hasUartService = dev.advertisement.serviceUuids &&
-                           dev.advertisement.serviceUuids.indexOf(NORDIC_SERVICE)>=0;
+                           dev.advertisement.serviceUuids.map(s => s.replaceAll('-', '')).indexOf(NORDIC_SERVICE)>=0;
       if (hasUartService ||
           Espruino.Core.Utils.isRecognisedBluetoothDevice(name, dev.address)) {
         console.log("Noble: Found UART device:", name, dev.address);


### PR DESCRIPTION
The services UUID reported by Noble contain hyphens, therefore not properly matching the `NORDIC_SERVICE`  defined without hyphen.

https://github.com/espruino/EspruinoTools/blob/1b9109dcd847c8354d96316fa990133f13ba6fa6/core/serial_noble.js#L12

This cause the `espruino --list` call to not list devices that advertised the service.

This PR removes the hyphens from the UUIDs before comparing them.