### PR TITLE
fix line splitting for storage file uploads

### DIFF
--- a/core/serial.js
+++ b/core/serial.js
@@ -355,7 +355,7 @@ To add a new serial device, you must add an object to
       split = findSplitIdx(split, /reset\(\);\n/, 250, "reset()"); // Reset
       split = findSplitIdx(split, /load\(\);\n/, 250, "load()"); // Load
       split = findSplitIdx(split, /Modules.addCached\("[^\n]*"\);\n/, 250, "Modules.addCached"); // Adding a module
-      split = findSplitIdx(split, /\x10require\("Storage"\).write\([^\n]*\);\n/, 500, "Storage.write"); // Write chunk of data
+      split = findSplitIdx(split, /\x10[^\n]*require\("Storage"\).write\([^\n]*\)[;]?\n/, 500, "Storage.write"); // Write chunk of data
     }
     // Otherwise split based on block size
     if (!split.match || split.end >= writeData[0].blockSize) {


### PR DESCRIPTION
Line number setting which is by default true adds something to the beginning and line does not end with semicolon, fix regex to match both issues.
Currently for me storage upload via --storage name:name contains something like `\u0010\u001b[83drequire(\"Storage\").write(` and line ends with something like `"),31872)\n` .
