### PR TITLE
Fix for issue #183. Was proceeding despite identifying OS is incompat…

### DIFF
--- a/core/serial_node_ble.js
+++ b/core/serial_node_ble.js
@@ -23,6 +23,7 @@
   if (typeof require === 'undefined') return;
   if (require("os").platform() != "linux") {
     console.log("serial_node_ble: Not running Linux - disabling Bluetooth DBUS support");
+    return;
   }
 
   const NORDIC_SERVICE = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";


### PR DESCRIPTION
…ible with node-ble library.

Fix for #183 

The node-ble module only supports Linux (see https://github.com/chrvadala/node-ble/issues/31 ).

This has clearly been identified in the past because there exists the following:

```
if (require("os").platform() != "linux") {
    console.log("serial_node_ble: Not running Linux - disabling Bluetooth DBUS support");
}
```

But despite saying it is disabling DBUS support, it still continues. It should exit at that point and doesn't. So the fix is to add `return;` to that block.