### PR TITLE
Remove unused stringToArrayBuffer function

### DIFF
--- a/core/serial.js
+++ b/core/serial.js
@@ -268,20 +268,6 @@ To add a new serial device, you must add an object to
     });
   };
 
-  var str2ab=function(str) {
-    var buf=new ArrayBuffer(str.length);
-    var bufView=new Uint8Array(buf);
-    for (var i=0; i<str.length; i++) {
-      var ch = str.charCodeAt(i);
-      if (ch>=256) {
-        console.warn("serial> Attempted to send non-8 bit character - code "+ch);
-        ch = "?".charCodeAt(0);
-      }
-      bufView[i] = ch;
-    }
-    return buf;
-  };
-
   var closeSerial=function() {
     if (currentDevice) {
       currentDevice.close();


### PR DESCRIPTION
This function isn't called anywhere, it also already exists in utils https://github.com/espruino/EspruinoTools/blob/master/core/utils.js#L784-L796