### PR TITLE
Correction to error handling on serial_node_ble

### DIFF
--- a/core/serial_node_ble.js
+++ b/core/serial_node_ble.js
@@ -122,11 +122,12 @@
     }
 
     getAdapter().then((adapter) =>
-    scanDevices(adapter)).catch(() =>
-      callback([], true)
-    ).then((devices) =>
+    scanDevices(adapter)).then((devices) =>
       callback(devices, false)
-    );
+    ).catch((err) => {
+      console.error("serial_node_ble", "error on scanDevices", err)
+      callback([], true)
+    })
   };
 
   var closeSerial = function () {


### PR DESCRIPTION
Changed the error handing of `scanDevices` to fix #194 

Also added a log in there to help identify the actual errors when they occur.